### PR TITLE
feat: add opt-in debug mode for console logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Console logging is now opt-in via `debug` option**: Label visibility warnings (e.g., "Hiding label because arc span is too narrow") no longer appear by default. Pass `debug: true` to `renderSVG()` to enable diagnostic logging for debugging layout issues.
+
 ## [0.3.2] - 2025-10-23
 
 ### Refactoring

--- a/src/render/svg.ts
+++ b/src/render/svg.ts
@@ -216,6 +216,7 @@ export function renderSVG(options: RenderSvgOptions): RenderHandle {
           cx,
           cy,
           navigationMorph,
+          debug: state.currentOptions.debug ?? false,
         });
       }
     }
@@ -494,11 +495,12 @@ function updateManagedPath(
       drivers,
       cx,
       cy,
+      debug: options.debug ?? false,
     });
   } else {
     stopArcAnimation(managed);
     applyPathData(element, pathData);
-    updateArcLabel(managed, arc, { cx, cy, allowLogging: true });
+    updateArcLabel(managed, arc, { cx, cy, allowLogging: options.debug ?? false });
   }
 
   // Apply color from theme or node.color override
@@ -867,8 +869,9 @@ function startArcAnimation(params: {
   drivers: AnimationDrivers;
   cx: number;
   cy: number;
+  debug: boolean;
 }): void {
-  const { managed, from, to, finalPath, transition, drivers, cx, cy } = params;
+  const { managed, from, to, finalPath, transition, drivers, cx, cy, debug } = params;
   stopArcAnimation(managed);
 
   const element = managed.element;
@@ -885,12 +888,12 @@ function startArcAnimation(params: {
     },
     onComplete: () => {
       applyPathData(element, finalPath);
-      updateArcLabel(managed, to, { cx, cy, allowLogging: true });
+      updateArcLabel(managed, to, { cx, cy, allowLogging: debug });
       managed.animation = null;
     },
     onCancel: () => {
       applyPathData(element, finalPath);
-      updateArcLabel(managed, to, { cx, cy, allowLogging: true });
+      updateArcLabel(managed, to, { cx, cy, allowLogging: debug });
       managed.animation = null;
     },
   });
@@ -1045,8 +1048,9 @@ function scheduleManagedRemoval(params: {
   cx: number;
   cy: number;
   navigationMorph: boolean;
+  debug: boolean;
 }): void {
-  const { key, managed, host, registry, transition, drivers, cx, cy, navigationMorph } = params;
+  const { key, managed, host, registry, transition, drivers, cx, cy, navigationMorph, debug } = params;
   if (managed.pendingRemoval) {
     return;
   }
@@ -1089,6 +1093,7 @@ function scheduleManagedRemoval(params: {
       drivers,
       cx,
       cy,
+      debug,
     });
   }
 

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -154,6 +154,7 @@ export interface RenderSvgOptions {
   breadcrumbs?: boolean | BreadcrumbOptions;
   transition?: boolean | TransitionOptions;
   navigation?: boolean | NavigationOptions;
+  debug?: boolean;
   onArcEnter?: (payload: ArcPointerEventPayload) => void;
   onArcMove?: (payload: ArcPointerEventPayload) => void;
   onArcLeave?: (payload: ArcPointerEventPayload) => void;


### PR DESCRIPTION
## Summary

Implements opt-in debug mode for console logging. Console messages (label visibility warnings) are now disabled by default and only appear when `debug: true` is passed to `renderSVG()`.

## Changes

- Add `debug?: boolean` option to `RenderSvgOptions` interface
- Thread debug flag through `updateManagedPath`, `startArcAnimation`, and `scheduleManagedRemoval` functions
- Replace hardcoded `allowLogging: true` with `debug ?? false`
- Update CHANGELOG.md with the new opt-in behavior

## Motivation

Reduces console noise in production while keeping diagnostic information available during development. Users were seeing unwanted `console.info` messages like "Hiding label because arc span is too narrow" without any way to disable them.

## Usage

```javascript
// No console messages (default)
renderSVG({
  el: '#chart',
  config
});

// Enable debug messages
renderSVG({
  el: '#chart',
  config,
  debug: true
});
```

## Test plan

- [x] All existing tests pass (38/38)
- [x] Build succeeds without TypeScript errors
- [x] CHANGELOG.md updated
- [x] Backward compatible (debug defaults to false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)