### PR TITLE
fix: correct label positioning and orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Label positioning and orientation**: Fixed two critical label rendering bugs:
+  - Labels are now properly centered on arcs instead of appearing offset to the bottom-left. Added `text-anchor: middle` attribute to `<textPath>` elements for correct SVG text alignment.
+  - Label inversion now uses tangent direction instead of midpoint angle, ensuring labels are always readable regardless of arc configuration. Labels at 0° and 180° now have correct orientation in all cases.
+
 ### Changed
 - **Console logging is now opt-in via `debug` option**: Label visibility warnings (e.g., "Hiding label because arc span is too narrow") no longer appear by default. Pass `debug: true` to `renderSVG()` to enable diagnostic logging for debugging layout issues.
 

--- a/src/render/svg.ts
+++ b/src/render/svg.ts
@@ -362,6 +362,7 @@ function createManagedPath(params: {
   textPathElement.setAttribute('startOffset', '50%');
   textPathElement.setAttribute('method', 'align');
   textPathElement.setAttribute('spacing', 'auto');
+  textPathElement.setAttribute('text-anchor', 'middle');
   textPathElement.setAttribute('class', 'sand-arc-label-textpath');
   textPathElement.textContent = '';
   textPathElement.style.pointerEvents = 'none';
@@ -695,11 +696,27 @@ function evaluateLabelVisibility(arc: LayoutArc, text: string, cx: number, cy: n
 
   const angle = (arc.x0 + arc.x1) * 0.5;
   const point = polarToCartesian(cx, cy, midRadius, angle);
-  // Normalize angle to [0, TAU) range
-  const normalizedAngle = ((angle % TAU) + TAU) % TAU;
-  // Invert text on the left half of the circle to keep it readable
-  // Include bottom boundary (π/2) but not top boundary (3π/2)
-  const inverted = normalizedAngle >= Math.PI / 2 && normalizedAngle < (Math.PI * 3) / 2;
+
+  // Compute a small delta angle for local sampling (keeps delta proportional to arc span)
+  const smallDelta = Math.min(Math.max(span * 0.01, 1e-4), 0.1);
+
+  // Sample points just before and after midpoint
+  const aBefore = angle - smallDelta;
+  const aAfter = angle + smallDelta;
+  const pBefore = polarToCartesian(cx, cy, midRadius, aBefore);
+  const pAfter = polarToCartesian(cx, cy, midRadius, aAfter);
+
+  // Tangent vector in screen coordinates
+  const tx = pAfter.x - pBefore.x;
+  const ty = pAfter.y - pBefore.y;
+
+  // Tangent angle in [-π, π]
+  const tangentAngle = Math.atan2(ty, tx);
+  // Normalize to [0, TAU)
+  const normalizedTangent = ((tangentAngle % TAU) + TAU) % TAU;
+
+  // Invert when tangent points leftwards (between 90° and 270°)
+  const inverted = normalizedTangent >= Math.PI / 2 && normalizedTangent < (3 * Math.PI) / 2;
   const pathData = createLabelArcPath({
     arc,
     radius: midRadius,


### PR DESCRIPTION
## Summary

Fixes two critical label rendering bugs affecting label positioning and text orientation.

## Issues Fixed

### 1. Label Positioning Bug
**Problem**: Labels appeared offset to the bottom-left of arcs instead of being centered.

**Root Cause**: The `text-anchor: middle` attribute was only set on the parent `<text>` element, but SVG requires this attribute on the `<textPath>` element itself to properly center text along a path.

**Solution**: Added `text-anchor: middle` attribute to the `<textPath>` element (svg.ts:365).

### 2. Label Orientation Bug
**Problem**: Labels at 0° and 180° had incorrect inversion (upside-down when they should be upright, or vice versa) in certain arc configurations.

**Root Cause**: The inversion logic used the midpoint angle of the arc, which doesn't always match the actual direction the text flows along the path, especially for arcs generated by free layout mode with offsets.

**Solution**: Calculate the tangent direction by sampling two nearby points and use the tangent angle to determine inversion. This ensures labels are always readable regardless of how the arc was configured.

## Changes

### src/render/svg.ts
- **Line 365**: Add `text-anchor: middle` to textPath element
- **Lines 700-720**: Replace midpoint-based inversion with tangent-based calculation
  - Sample points before/after midpoint
  - Calculate tangent vector from screen coordinates
  - Use tangent angle for inversion decision

### CHANGELOG.md
- Document both fixes under "Fixed" section

## Technical Details

The new tangent-based inversion works by:
1. Computing a small delta angle proportional to arc span
2. Sampling points just before and after the arc midpoint
3. Computing the tangent vector in screen coordinates
4. Converting to tangent angle with `Math.atan2(ty, tx)`
5. Normalizing to [0, 2π) range
6. Inverting when tangent points leftward (90° to 270°)

This method is more robust than the previous approach because it measures the **actual direction** text will be drawn, not just the position of the arc center.

## Test Plan

- [x] Created test page (demo/label-test.html) with 12 test cases
- [x] Verified labels are centered on arcs (not offset)
- [x] Verified correct inversion at all angles (0°, 45°, 90°, 135°, 180°, 225°, 270°, 315°)
- [x] Verified correct behavior for full-circle layouts
- [x] Build succeeds without errors
- [x] All existing tests pass

## Before/After

**Before**: Labels offset to bottom-left, wrong orientation at 0°/180°
**After**: Labels centered, correct orientation at all angles

🤖 Generated with [Claude Code](https://claude.com/claude-code)